### PR TITLE
fix: Miscalculation of gasLimit on join with walletconnect

### DIFF
--- a/packages/web-app/hooks/useAgreement.tsx
+++ b/packages/web-app/hooks/useAgreement.tsx
@@ -117,6 +117,9 @@ export const useAgreementJoin = () => {
 		onError(error) {
 			console.log(error);
 		},
+		overrides: {
+			gasLimit: 260000,
+		},
 	});
 
 	const { isLoading: isProcessing, isSuccess: isTxSuccess } = useWaitForTransaction({


### PR DESCRIPTION
When using WalletConnect integration the tx to join the agreement was setting a lower gas limit than was needed. This should fix it for now.
