### PR TITLE
Fix invalid signing

### DIFF
--- a/packages/web-app/components/JoinModal.tsx
+++ b/packages/web-app/components/JoinModal.tsx
@@ -381,7 +381,7 @@ export const JoinModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: bo
 		[tokenTransfers, frameworkAddress, address],
 	);
 
-	const { permit, signature, signPermit, signError, signSuccess } =
+	const { permit, signature, signPermit, signError, signSuccess, signReady } =
 		usePermit2BatchTransferSignature(usePermit2BatchTransferSignatureConfig);
 
 	useEffect(() => {
@@ -450,7 +450,7 @@ export const JoinModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: bo
 
 	const signAction = useMemo(() => {
 		if (signSuccess && signature) return <CheckCircleIcon className="w-7 h-7 text-bluesky" />;
-		if (signLoading) return <Spinner className="w-6 h-6 text-bluesky" />;
+		if (signLoading || !signReady) return <Spinner className="w-6 h-6 text-bluesky" />;
 		return (
 			<CompactOutlineButton
 				label={t("join.signPermit.action")}
@@ -460,12 +460,9 @@ export const JoinModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: bo
 				}}
 			/>
 		);
-	}, [signSuccess, signature, signLoading]);
+	}, [signSuccess, signature, signLoading, signPermit, signReady]);
 
 	const canJoin = useMemo(() => {
-		console.log("balance", enoughBalance);
-		console.log("permit2", usePermit2);
-		console.log("signature", signature);
 		if (!enoughBalance) return false;
 		if (usePermit2) {
 			return signature !== undefined ? true : false;


### PR DESCRIPTION
**Post-mortem**
- #111 Added a hook to show "Approve transfers" button based on certain conditions.
- #101 Used a placeholder Permit with nonce 0 as quick solution in the hook until the fetch of the next nonce available for Permit2 signature allowance, which caused the configuration for signing to load twice.
- Missing dependency of `signPermit()` function in the "Approve transfers" button hook caused it to not reload properly, leading to a scenario where the user was prompted with a different Permit to sign than the one that would be sent to the contract, breaking the join.

**Solution**
- Omitted placeholder Permit and initially load `signPermit()` with incomplete configuration to prevent prompting the user to sign a placeholder Permit.
- Added a `signReady` flag to signal when the Permit is ready for signature and included it in the button hook to prevent initiating signing before the Permit is ready.

**TL;DR:**
We fixed the issue where users were prompted to sign a placeholder Permit by omitting it and adding a `signReady` flag to ensure signing only happens when the Permit is ready.
