### PR TITLE
Fix Ledger signatures (and other non compliant ECDSA signatures)

### DIFF
--- a/packages/web-app/components/JoinModal.tsx
+++ b/packages/web-app/components/JoinModal.tsx
@@ -621,17 +621,6 @@ export const JoinModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: bo
 						</div>
 					</div>
 				</div>
-				{usePermit2 && (
-					<div className="absolute mt-3 left-1/2 transform -translate-x-1/2 flex p-base gap-1 items-center justify-between bg-yellow-100 rounded-bottom-lg rounded-lg text-sm">
-						<div className="px-5">
-							<ExclamationTriangleIcon className="w-4 h-4 text-yellow-800" />
-						</div>
-						<p className="grow flex flex-col text-yellow-600">
-							<span>Gassless approvals reportedly causing problems with Ledger wallets.</span>
-							<span>Use traditional approvals if you are using Ledger.</span>
-						</p>
-					</div>
-				)}
 			</section>
 		</ModalNew>
 	);

--- a/packages/web-app/hooks/usePermit2.tsx
+++ b/packages/web-app/hooks/usePermit2.tsx
@@ -10,7 +10,7 @@ import { firstZeroBitPosition } from "../utils/bytes";
 import { BigNumber, BigNumberish, constants } from "ethers";
 import { useEffect, useMemo, useState } from "react";
 import { useConstants } from "./useConstants";
-import { fixVInSignature } from "../utils/signaturefix";
+import { fixSignature } from "../utils/signature";
 
 interface Permit2AllowanceConfig {
 	account: string;
@@ -118,13 +118,12 @@ export const usePermit2TransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	let signatureFix = signature;
+	const fixedSignature = useMemo(() => {
+		if (!signSuccess || !signature) return;
+		return fixSignature(signature);
+	}, [signSuccess, signature]);
 
-	if (signSuccess && signature) {
-		signatureFix = fixVInSignature(signature);
-	}
-
-	return { permit, signature: signatureFix, signPermit, signSuccess, signError };
+	return { permit, signature: fixedSignature, signPermit, signSuccess, signError };
 };
 
 export const usePermit2BatchTransferSignature = ({
@@ -179,13 +178,12 @@ export const usePermit2BatchTransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	let signatureFix = signature;
+	const fixedSignature = useMemo(() => {
+		if (!signSuccess || !signature) return;
+		return fixSignature(signature);
+	}, [signSuccess, signature]);
 
-	if (signSuccess && signature) {
-		signatureFix = fixVInSignature(signature);
-	}
-
-	return { permit, signature: signatureFix, signPermit, signSuccess, signError, signReady };
+	return { permit, signature: fixedSignature, signPermit, signSuccess, signError, signReady };
 };
 
 export const useAvailableNonce = (address: string) => {

--- a/packages/web-app/hooks/usePermit2.tsx
+++ b/packages/web-app/hooks/usePermit2.tsx
@@ -10,6 +10,7 @@ import { firstZeroBitPosition } from "../utils/bytes";
 import { BigNumber, BigNumberish, constants } from "ethers";
 import { useEffect, useMemo, useState } from "react";
 import { useConstants } from "./useConstants";
+import { fixVInSignature } from "../utils/signaturefix";
 
 interface Permit2AllowanceConfig {
 	account: string;
@@ -117,7 +118,13 @@ export const usePermit2TransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	return { permit, signature, signPermit, signSuccess, signError };
+	let eip155signature = signature;
+
+	if (signSuccess && signature) {
+		eip155signature = fixVInSignature(signature);
+	}
+
+	return { permit, signature: eip155signature, signPermit, signSuccess, signError };
 };
 
 export const usePermit2BatchTransferSignature = ({
@@ -172,7 +179,13 @@ export const usePermit2BatchTransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	return { permit, signature, signPermit, signSuccess, signError, signReady };
+	let eip155signature = signature;
+
+	if (signSuccess && signature) {
+		eip155signature = fixVInSignature(signature);
+	}
+
+	return { permit, signature: eip155signature, signPermit, signSuccess, signError, signReady };
 };
 
 export const useAvailableNonce = (address: string) => {

--- a/packages/web-app/hooks/usePermit2.tsx
+++ b/packages/web-app/hooks/usePermit2.tsx
@@ -118,13 +118,13 @@ export const usePermit2TransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	let eip155signature = signature;
+	let signatureFix = signature;
 
 	if (signSuccess && signature) {
-		eip155signature = fixVInSignature(signature);
+		signatureFix = fixVInSignature(signature);
 	}
 
-	return { permit, signature: eip155signature, signPermit, signSuccess, signError };
+	return { permit, signature: signatureFix, signPermit, signSuccess, signError };
 };
 
 export const usePermit2BatchTransferSignature = ({
@@ -179,13 +179,13 @@ export const usePermit2BatchTransferSignature = ({
 		signTypedData: signPermit,
 	} = useSignTypedData(signTypedDataConfig);
 
-	let eip155signature = signature;
+	let signatureFix = signature;
 
 	if (signSuccess && signature) {
-		eip155signature = fixVInSignature(signature);
+		signatureFix = fixVInSignature(signature);
 	}
 
-	return { permit, signature: eip155signature, signPermit, signSuccess, signError, signReady };
+	return { permit, signature: signatureFix, signPermit, signSuccess, signError, signReady };
 };
 
 export const useAvailableNonce = (address: string) => {

--- a/packages/web-app/utils/signature.tsx
+++ b/packages/web-app/utils/signature.tsx
@@ -1,0 +1,11 @@
+/** Some wallets (e.g. Metamask + Ledger) return a signature with a v value of 0 or 1, which is not valid.
+ * This function fixes the signature by changing the v value to 27 or 28. */
+export const fixSignature = (signature: string): string => {
+	let v = parseInt(signature.slice(-2), 16);
+
+	if (v < 27) {
+		v = v + 27;
+	}
+
+	return signature.slice(0, -2) + v.toString(16);
+};

--- a/packages/web-app/utils/signaturefix.tsx
+++ b/packages/web-app/utils/signaturefix.tsx
@@ -1,9 +1,0 @@
-export const fixVInSignature = (signature: string): string => {
-	let v = parseInt(signature.slice(-2), 16);
-
-	if (v < 27) {
-		v = v + 27;
-	}
-
-	return signature.slice(0, -2) + v.toString(16);
-};

--- a/packages/web-app/utils/signaturefix.tsx
+++ b/packages/web-app/utils/signaturefix.tsx
@@ -1,0 +1,9 @@
+export const fixVInSignature = (signature: string): string => {
+	let v = parseInt(signature.slice(-2), 16);
+
+	if (v < 27) {
+		v = v + 27;
+	}
+
+	return signature.slice(0, -2) + v.toString(16);
+};


### PR DESCRIPTION
Ledger produces `v,r,s` signatures with a canonical v value of {0,1}, while Ethereum's `ecrecover` call only accepts a non-standard v value of {27,28}. More on that [here](https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739).

Ledger was producing signatures that are not compatible with Ethereum's ECDSA implementation, and thus was failing on the public key recovery process.

As shown by Tenderly, the public key recovery was resulting in `address(0)` even if a Ledger message appeared to be signed correctly.

<img width="618" alt="image" src="https://github.com/nation3/court-app/assets/123108698/8a8ed25a-b636-4070-be4e-bafdfb91269c">
